### PR TITLE
ocifs works on Windows too

### DIFF
--- a/ocifs/core.py
+++ b/ocifs/core.py
@@ -426,7 +426,7 @@ class OCIFileSystem(AbstractFileSystem):
                     # ODSC-38899: phantom files get created, named the same as subdir
                     if f.name.endswith("/") and f.size == 0:
                         continue
-                    new_key = os.path.join(full_bucket_name, f.name)
+                    new_key = "/".join([full_bucket_name, f.name])
                     formatted_files.append(
                         CaseInsensitiveDict(
                             {


### PR DESCRIPTION
When you run on the code on Windows the os.path returns "\" and this is not works on oci that expects "/"