### PR TITLE
GitHub Actions: Transitioning from Node 16 to Node 20

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Build distribution 📦


### PR DESCRIPTION
### Description

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20
Jira: https://jira.oci.oraclecorp.com/browse/ODSC-52248

### What was done

- updated versions in used actions for checkout, setup-python