### PR TITLE
Add OKE principal signer support

### DIFF
--- a/ocifs/__init__.py
+++ b/ocifs/__init__.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-from .core import OCIFileSystem
-from fsspec import register_implementation
 import sys
-from .utils import __version__
 
+from fsspec import register_implementation
+
+from .core import OCIFileSystem
+from .utils import __version__
 
 if sys.version_info.major < 3:
     raise ImportError("Python < 3 is unsupported.")

--- a/ocifs/core.py
+++ b/ocifs/core.py
@@ -1,42 +1,41 @@
 # coding: utf-8
 # Copyright (c) 2021, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-import os
-from ast import literal_eval
 import inspect
 import logging
-from typing import Union  # pragma: no cover
 import mimetypes
+import os
+from ast import literal_eval
+from typing import Union  # pragma: no cover
 
 from fsspec import AbstractFileSystem
-from fsspec.utils import tokenize, stringify_path
 from fsspec.spec import AbstractBufferedFile
-
-from oci.signer import AbstractBaseSigner
+from fsspec.utils import stringify_path, tokenize
+from oci._vendor.requests.structures import CaseInsensitiveDict
 from oci.auth.signers import (
-    get_resource_principals_signer,
     InstancePrincipalsSecurityTokenSigner,
+    get_oke_workload_identity_resource_principal_signer,
+    get_resource_principals_signer,
 )
-from oci.config import DEFAULT_PROFILE, from_file, DEFAULT_LOCATION
-from oci.exceptions import ServiceError, ConfigFileNotFound
-
+from oci.config import DEFAULT_LOCATION, DEFAULT_PROFILE, from_file
+from oci.exceptions import ConfigFileNotFound, ServiceError
 from oci.object_storage.models import (
-    CreateBucketDetails,
     CommitMultipartUploadDetails,
-    CreateMultipartUploadDetails,
     CopyObjectDetails,
+    CreateBucketDetails,
+    CreateMultipartUploadDetails,
 )
 from oci.pagination import list_call_get_all_results
 from oci.retry import DEFAULT_RETRY_STRATEGY
-from oci._vendor.requests.structures import CaseInsensitiveDict
-from .errors import translate_oci_error
+from oci.signer import AbstractBaseSigner
+
 from ocifs.data_lake.lake_sharing_object_storage_client import (
     LakeSharingObjectStorageClient,
 )
 from ocifs.data_lake.rename_object_details import RenameObjectDetails
 
+from .errors import translate_oci_error
 from .utils import __version__
-
 
 logger = logging.getLogger("ocifs")
 
@@ -56,7 +55,7 @@ def setup_logging(level=None):
 if "OCIFS_LOGGING_LEVEL" in os.environ:
     setup_logging()
 
-IAM_POLICIES = {"api_key", "resource_principal", "instance_principal", "unknown_signer"}
+IAM_POLICIES = {"api_key", "resource_principal", "instance_principal", "unknown_signer", "oke_principal"}
 EU_SOVEREIGN_CLOUD_REGIONS = ["eu-frankfurt-2", "eu-madrid-2"]
 
 
@@ -229,7 +228,7 @@ class OCIFileSystem(AbstractFileSystem):
                 self.connect(refresh=True)
                 return method(**additional_kwargs)
             raise e
-
+    
     def sync(self, src_dir, dest_dir, **kwargs):
         """
         The `sync` method is a bulk copy where one location is local and the other is OCI Object Storage.
@@ -251,6 +250,7 @@ class OCIFileSystem(AbstractFileSystem):
             List of all args/kwargs here: https://docs.oracle.com/en-us/iaas/tools/oci-cli/3.22.4/oci_cli_docs/cmdref/os/object/sync.html
         """
         import subprocess
+
         import pkg_resources
 
         assert (
@@ -1129,6 +1129,13 @@ class OCIFileSystem(AbstractFileSystem):
 
     def _set_up_resource_principal(self):
         self.config_kwargs["signer"] = get_resource_principals_signer()
+
+    def _set_up_oke_principal(self):
+        signer = get_oke_workload_identity_resource_principal_signer()
+        self.config_kwargs["signer"] = signer
+        region = os.environ.get("OCI_REGION")
+        if region:
+            self.config.update(region=region)
 
     def _set_up_instance_principal(self):
         self.config_kwargs["signer"] = InstancePrincipalsSecurityTokenSigner()

--- a/ocifs/errors.py
+++ b/ocifs/errors.py
@@ -4,7 +4,6 @@
 import errno
 import functools
 
-
 # Fallback values since some systems might not have these.
 EREMOTEIO = getattr(errno, "EREMOTEIO", errno.EIO)
 

--- a/ocifs/utils.py
+++ b/ocifs/utils.py
@@ -4,7 +4,6 @@
 
 import sys
 
-
 __version__ = "UNKNOWN"
 # https://packaging.python.org/en/latest/guides/single-sourcing-package-version/#single-sourcing-the-package-version
 if sys.version_info >= (3, 8):


### PR DESCRIPTION
I added the OKE signer support to the [ocifs/core.py](https://github.com/oracle/ocifs/compare/main...nitin-rao-oci:ocifs:oke_signer_support?expand=1#diff-5d21df02949628478d2487eb482f66d4213cedcfedb69b4f03a2e51ae2392ee0) file, and also made minor formatting changes to the import statements. 